### PR TITLE
Fix: Error registration on duplicate email

### DIFF
--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -26,9 +26,9 @@ export default function SignUp() {
   const handleSubmit = async () => {
     const data = { nome, email, senha };
     const response = await post(data, "cadastro");
-    router.navigate('/profile');
     if (response && response.erro) {
       setErrorMessage(response.erro);
+      window.alert(response.erro); // medida provisoria
       return;
     }
      
@@ -36,6 +36,8 @@ export default function SignUp() {
       await AsyncStorage.setItem("userId", response.id.toString());
       router.navigate("/profile");
     }
+
+    router.navigate('/profile');
   };
 
   return (

--- a/server.php
+++ b/server.php
@@ -31,8 +31,17 @@ $data = json_decode(file_get_contents("php://input"), true);
 
 // Requisição POST para cadastro ou login
 if ($requestMethod === "POST" && isset($_GET["endpoint"])) {
-    if ($_GET["endpoint"] === "cadastro") {
+  if ($_GET["endpoint"] === "cadastro") {
+        // Checa se o usuario existe antes de criar
         if (!empty($data["nome"]) && !empty($data["email"]) && !empty($data["senha"])) {
+            $stmt = $pdo->prepare("SELECT email from usuarios where email = :email");
+            $stmt->bindParam(":email", $data["email"]);
+            $stmt->execute();
+            $usuarioExiste = $stmt->fetch(PDO::FETCH_ASSOC);
+            if($usuarioExiste){
+                echo json_encode(["erro" => "Usuario já existente"]);
+                exit(1);
+            }
             $senhaHash = password_hash($data["senha"], PASSWORD_DEFAULT);
             $stmt = $pdo->prepare("INSERT INTO usuarios (nome, email, senha, ativo) VALUES (:nome, :email, :senha, 'true')");
             $stmt->bindParam(":nome", $data["nome"]);


### PR DESCRIPTION
#  Bug Fix: Prevent Overwriting Existing User on Duplicate Email

## The problem
Attempting to register a new user with an email that’s already in use would overwrite the existing user data.
  
##  Fix
Before creating a new user do:

1. Check if the submitted email already exists.  
If it does, return 1 with error message: "Usuario já existente".
If it doesn't, create a user and take'em to the Home page.
